### PR TITLE
(17.18.0) DEVOPS-7607: Report failure if results are not available in salt redis return

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,10 @@
 Release Notes
 =============
-v0.1.1 First working version
-v0.1.2 Make changes in redis key structure for salt 2016 compatibility
-v0.1.3 Fix bug when reading the redis return
-v0.1.4 Add facility to read the last redis return without tracking a currently running highstate.
-v0.1.5 Fix formatting of log message.
-v0.1.6 Add salt-nanny command line utility to track returns from running highstate.
-v0.1.7 Update Documentation & improve command line utility
+v0.1.1 First working version\n
+v0.1.2 Make changes in redis key structure for salt 2016 compatibility\n
+v0.1.3 Fix bug when reading the redis return\n
+v0.1.4 Add facility to read the last redis return without tracking a currently running highstate.\n
+v0.1.5 Fix formatting of log message.\n
+v0.1.6 Add salt-nanny command line utility to track returns from running highstate.\n
+v0.1.7 Update Documentation & improve command line utility\n
+v0.1.9 Fixed bug to return exit code 2 if no returns are found.

--- a/saltnanny/salt_nanny.py
+++ b/saltnanny/salt_nanny.py
@@ -65,7 +65,8 @@ class SaltNanny:
     def parse_last_return(self):
         for minion in self.minion_list:
             latest_jid = self.cache_client.get_latest_jid(minion, self.fun)
-            self.completed_minions[minion] = latest_jid
+            if latest_jid != '0':
+                self.completed_minions[minion] = latest_jid
         self.log.info(self.completed_minions)
         return self.parser.process_jids(self.completed_minions, len(self.minion_list))
 

--- a/saltnanny/salt_nanny_tool.py
+++ b/saltnanny/salt_nanny_tool.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from argparse import ArgumentParser
-from saltnanny import SaltNanny
+from salt_nanny import SaltNanny
 
 
 def get_args():

--- a/saltnanny/salt_return_parser.py
+++ b/saltnanny/salt_return_parser.py
@@ -28,8 +28,8 @@ class SaltReturnParser:
                 self.log.error('Error retrieving results for Minion:{0}: Exception:{1}'.format(minion, ve))
 
         if not completed_minions:
-            self.log.info('No highstates found in Job Cache, setting return_code_sum = 2')
-            return_code_sum = 2
+            self.log.info('No highstates found in Job Cache.')
+            return 2
 
         if len(completed_minions) != all_minions_count and return_code_sum == 0:
             self.log.info('Highstates available in Job Cache were successful, timed out waiting for others.')

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def get_required_modules(file_name):
 
 setup(
     name="saltnanny",
-    version="0.1.8",
+    version="0.1.9",
     author="Dun and Bradstreet Inc.",
     author_email="devops@dandb.com",
     description='Python Module that parses salt returns stored in an external job cache and logs output',


### PR DESCRIPTION
**Testing:** 
Confirmed exit code is non zero when no redis returns exit in redis.
```
[root@saltmaster ~]# redis-cli FLUSHALL
OK
[root@saltmaster ~]# salt-nanny localhost saltmaster -r
2017-04-28 11:25:26,214 INFO Latest jid for Minion:saltmaster JID:0
2017-04-28 11:25:26,214 INFO Latest jid for Minion:saltmaster JID:0
2017-04-28 11:25:26,214 INFO {}
2017-04-28 11:25:26,214 INFO No highstates found in Job Cache.
[root@saltmaster ~]# echo $?
2
```
