### PR TITLE
DEVOPS-9280: Added new command line parameter to only return results that have higher jid

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,3 +8,5 @@ v0.1.5 Fix formatting of log message.\n
 v0.1.6 Add salt-nanny command line utility to track returns from running highstate.\n
 v0.1.7 Update Documentation & improve command line utility\n
 v0.1.9 Fixed bug to return exit code 2 if no returns are found.
+v0.2.0 Added new command line parameter(earliest_jid) to only return saltmaster results more recent than the passed jid
+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ salt-nanny localhost minion1 minion2 -p 6380 -x 20 -I 5 60 2
 This command tells salt-nanny to wait 5, 10, 20, 40 and 60 seconds between each retry initially and then 60s for
 subsequent retries. Attempt 20 times and then give up. Use port 6380 for redis.
 
+```
+salt-nanny localhost minion1 -r -j 20170905144844350779
+```
+This command tells salt-nanny to return results from minion minion1 that have higher JID than 20170905144844350779
+
 *Example Python code:*
 ```
 #!/usr/bin/env python

--- a/saltnanny/salt_nanny.py
+++ b/saltnanny/salt_nanny.py
@@ -61,11 +61,14 @@ class SaltNanny:
                 break
         self.log.info(self.completed_minions)
         return self.parser.process_jids(self.completed_minions, len(self.minion_list))
-    
-    def parse_last_return(self):
+
+    def parse_last_return(self, earliest_jid=0):
         for minion in self.minion_list:
             latest_jid = self.cache_client.get_latest_jid(minion, self.fun)
-            if latest_jid != '0':
+            if int(latest_jid) < earliest_jid:
+                self.log.info("No highstates found in job cache for minion: {0} after: {1}".format(minion, earliest_jid))
+                return 1
+            else:
                 self.completed_minions[minion] = latest_jid
         self.log.info(self.completed_minions)
         return self.parser.process_jids(self.completed_minions, len(self.minion_list))

--- a/saltnanny/salt_nanny_tool.py
+++ b/saltnanny/salt_nanny_tool.py
@@ -14,7 +14,7 @@ def get_args():
     parser.add_argument('-x', '--max-attempts', action='store', dest='max_attempts', type=int, default=15, help='Custom Event if this is not a highstate')
     parser.add_argument('-I', '--intervals', action='store', dest='intervals', type=int, nargs=3, default=[15, 60, 2], help='Custom Wait intervals and multiplier')
     parser.add_argument('-r', '--last-return', action='store_true', dest='last_return', help='Fetch last highstate result.')
-    parser.set_defaults(last_return=False)
+    parser.add_argument('-j', '--earliest-jid', action='store', dest='earliest_jid', nargs='?', default=0, type=int, help='Fetch last highstate result stored after this time')
     return parser.parse_args()
 
 
@@ -23,7 +23,7 @@ def tool_main():
     cache_config = {'type': args.type, 'host': args.host, 'port': args.port, 'db': '0'}
     salt_nanny = SaltNanny(cache_config, args.log_file, args.custom_event, args.intervals[0], args.intervals[1], args.intervals[2])
     salt_nanny.initialize(args.minions)
-    return salt_nanny.parse_last_return() if args.last_return else salt_nanny.track_returns(args.max_attempts)
+    return salt_nanny.parse_last_return(args.earliest_jid) if args.last_return else salt_nanny.track_returns(args.max_attempts)
 
 if __name__ == '__main__':
     exit(tool_main())

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def get_required_modules(file_name):
 
 setup(
     name="saltnanny",
-    version="0.1.9",
+    version="0.2.0",
     author="Dun and Bradstreet Inc.",
     author_email="devops@dandb.com",
     description='Python Module that parses salt returns stored in an external job cache and logs output',

--- a/tests/salt_nanny_tool_test.py
+++ b/tests/salt_nanny_tool_test.py
@@ -20,6 +20,7 @@ class ScriptsTest(unittest.TestCase):
     mock_args.minions = ['minion1']
     mock_args.max_attempts = 15
     mock_args.last_return = False
+    mock_args.earliest_jid = 20170905144844350780
 
     mock_args_return = copy(mock_args)
     mock_args_return.last_return = True
@@ -31,7 +32,7 @@ class ScriptsTest(unittest.TestCase):
     @patch.object(SaltNanny, 'track_returns')
     def test_tool_main(self, mock_track_returns, mock_initialize, mock_init, mock_parse_args, mock_add_argument):
         salt_nanny_tool.tool_main()
-        assert(mock_add_argument.call_count == 10)
+        assert(mock_add_argument.call_count == 11)
         assert(mock_parse_args.call_count == 1)
         mock_track_returns.assert_called_once()
 
@@ -42,6 +43,6 @@ class ScriptsTest(unittest.TestCase):
     @patch.object(SaltNanny, 'parse_last_return')
     def test_tool_main_return(self, mock_parse_last_return, mock_init, mock_initialize, mock_parse_args, mock_add_argument):
         salt_nanny_tool.tool_main()
-        assert(mock_add_argument.call_count == 10)
+        assert(mock_add_argument.call_count == 11)
         assert(mock_parse_args.call_count == 1)
         mock_parse_last_return.assert_called_once()


### PR DESCRIPTION
### Change Impact
Added new command line parameter(earliest_jid) to only return results that were stored after the given timestamp(represented by jid)

## Testing Evidence
Successfully processes the new parameter.
![screen shot 2017-09-06 at 3 04 34 pm](https://user-images.githubusercontent.com/15876670/30137373-d9b122aa-9317-11e7-95cb-206075275f3f.png)

The change is backwards compatible
![screen shot 2017-09-06 at 3 08 32 pm](https://user-images.githubusercontent.com/15876670/30137379-de0c2e4e-9317-11e7-96e0-b3c4828dae6e.png)
