### PR TITLE
DEVOPS-9710: Updated the setup.py with the correct git url for salt-nanny

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     description='Python Module that parses salt returns stored in an external job cache and logs output',
     license="GPLv3",
     keywords="Salt SaltStack Redis redis_return parse cache external",
-    url="https://github.com/dandb/saltnanny",
+    url="https://github.com/dandb/salt-nanny",
     packages=['saltnanny'],
     scripts=['salt-nanny'],
     include_package_data=True,


### PR DESCRIPTION
### Change Impact
Updated the setup.py with the correct git url for salt-nanny to fix issue with release to PyPI

## Testing Evidence
setup.py ran successfully 
![screen shot 2017-09-13 at 10 48 12 am](https://user-images.githubusercontent.com/15876670/30392365-7207cad2-9871-11e7-9421-f6dcefba8351.png)
