### PR TITLE
(17.51.0) DEVOPS-10055, updated list of possible failures for salt-nanny

### DIFF
--- a/saltnanny/salt_return_parser.py
+++ b/saltnanny/salt_return_parser.py
@@ -94,7 +94,13 @@ class SaltReturnParser:
 
     def highstate_failed(self, result):
         try:
-            possible_failures = ['"result": false', 'Data failed to compile:', 'Pillar failed to render with the following messages:']
+            possible_failures = [
+                '"result": false',
+                'Data failed to compile:',
+                'Pillar failed to render with the following messages:',
+                'Detected conflicting IDs',
+                'Cannot extend ID'
+            ]
             failures = [failure in result for failure in possible_failures]
             self.log.info(failures)
             if True not in failures:


### PR DESCRIPTION
Tested the code still packages and installs:

```
root@saltmaster salt-nanny (DEVOPS-10055)]# pip install . && date
You are using pip version 7.1.0, however version 9.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Processing /vagrant_data/projects/salt-nanny
Collecting redis (from saltnanny==0.2.0)
  Using cached redis-2.10.6-py2.py3-none-any.whl
Installing collected packages: redis, saltnanny
  Running setup.py install for saltnanny
Successfully installed redis-2.10.6 saltnanny-0.2.0
Tue Nov 21 16:55:23 PST 2017
```