### PR TITLE
DEVOPS-10055: updated version number

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,4 +9,5 @@ v0.1.6 Add salt-nanny command line utility to track returns from running highsta
 v0.1.7 Update Documentation & improve command line utility\n
 v0.1.9 Fixed bug to return exit code 2 if no returns are found.
 v0.2.0 Added new command line parameter(earliest_jid) to only return saltmaster results more recent than the passed jid
+v0.2.1 Updated list of potential_failures in salt_return_parser
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def get_required_modules(file_name):
 
 setup(
     name="saltnanny",
-    version="0.2.0",
+    version="0.2.1",
     author="Dun and Bradstreet Inc.",
     author_email="devops@dandb.com",
     description='Python Module that parses salt returns stored in an external job cache and logs output',


### PR DESCRIPTION
New version still packages and installs:

```
[root@saltmaster salt-nanny (DEVOPS-10055)]# pip install . && date
You are using pip version 7.1.0, however version 9.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Processing /vagrant_data/projects/salt-nanny
Requirement already satisfied (use --upgrade to upgrade): redis in /usr/lib/python2.6/site-packages (from saltnanny==0.2.1)
Installing collected packages: saltnanny
  Running setup.py install for saltnanny
Successfully installed saltnanny-0.2.1
Mon Dec  4 14:38:10 PST 2017
```