### PR TITLE
DEVOPS-10055: added unit test for parsing possible highstate failures

### DIFF
--- a/tests/resources/failed_highstate.json
+++ b/tests/resources/failed_highstate.json
@@ -1,0 +1,64 @@
+{
+  "fun_args": [],
+  "jid": "20160802115439359216",
+  "return": {
+    "service_|-sshd_|-sshd_|-running": {
+      "comment": "The service sshd is already running",
+      "name": "sshd",
+      "start_time": "11:55:04.421662",
+      "result": true,
+      "duration": 75.354,
+      "__run_num__": 118,
+      "changes": {}
+    },
+    "pkg_|-sendmail-packages-to-remove_|-exim_|-removed": {
+      "comment": "All specified packages are already absent",
+      "name": "exim",
+      "start_time": "11:55:03.935561",
+      "result": true,
+      "duration": 0.773,
+      "__run_num__": 104,
+      "changes": {}
+    },
+    "file_|-/etc/nsswitch.conf_|-/etc/nsswitch.conf_|-managed": {
+      "comment": "File /etc/nsswitch.conf is in the correct state",
+      "name": "/etc/nsswitch.conf",
+      "start_time": "11:54:46.700019",
+      "result": true,
+      "duration": 5.779,
+      "__run_num__": 13,
+      "changes": {}
+    },
+    "file_|-/etc/cron.daily/ntpdate.cron_|-/etc/cron.daily/ntpdate.cron_|-managed": {
+      "comment": "File /etc/cron.daily/ntpdate.cron is in the correct state",
+      "name": "/etc/cron.daily/ntpdate.cron",
+      "start_time": "11:55:03.768677",
+      "result": true,
+      "duration": 2.648,
+      "__run_num__": 85,
+      "changes": {}
+    },
+    "service_|-crond_|-crond_|-running": {
+      "comment": "The service crond is already running",
+      "name": "crond",
+      "start_time": "11:54:47.322022",
+      "result": true,
+      "duration": 28.982,
+      "__run_num__": 64,
+      "changes": {}
+    },
+    "file_|-/etc/pam.d/sshd_|-/etc/pam.d/sshd_|-managed": {
+      "comment": "Cannot extend ID",
+      "name": "/etc/pam.d/sshd",
+      "start_time": "11:55:04.497402",
+      "result": true,
+      "duration": 10.328,
+      "__run_num__": 119
+    }
+  },
+  "retcode": 2,
+  "success": false,
+  "fun": "state.highstate",
+  "id": "packer-dnbi",
+  "out": "highstate"
+}

--- a/tests/salt_return_parser_test.py
+++ b/tests/salt_return_parser_test.py
@@ -1,12 +1,20 @@
 import unittest
+import os
 from mock import patch
 from fakeredis import FakeRedis
-
 from saltnanny import SaltReturnParser
+from saltnanny import SaltNanny
 from saltnanny import SaltRedisClient
 
 
 class SaltReturnParserTest(unittest.TestCase):
+
+    cache_config = {
+        'type': 'redis',
+        'host': 'localhost',
+        'port': 6379,
+        'db': '0'
+    }
 
     @patch('redis.Redis')
     def setUp(self, mock_redis):
@@ -43,6 +51,29 @@ class SaltReturnParserTest(unittest.TestCase):
         self.parser.cache_client.redis_instance.set('minion1:1234', '{\"return\" : [\"The function state.highstate is running as PID 1234\"]}')
         result_code = self.parser.get_return_info('minion1', '1234')
         self.assertTrue(result_code > 0)
+
+
+    @patch('redis.Redis')
+    def test_parse_last_return_with_results(self, mock_redis):
+        fake_redis = FakeRedis()
+
+        # Create and initialize Salt Nanny
+        salt_nanny = SaltNanny(self.cache_config)
+        salt_nanny.cache_client.redis_instance = fake_redis
+        salt_nanny.initialize(['minion1'])
+        salt_nanny.min_interval = 1
+
+        with open('{0}/resources/failed_highstate.json'.format(os.path.dirname(__file__)), 'r') as f:
+            json = f.read()
+
+        # Make Redis Returns available in fake redis
+        salt_nanny.cache_client.redis_instance.set('minion1:state.highstate', '6789')
+        salt_nanny.cache_client.redis_instance.set('minion1:6789', json)
+
+        return_info = salt_nanny.cache_client.get_return_by_jid('minion1','6789')
+        is_failed = self.parser.highstate_failed(return_info)
+
+        self.assertTrue(is_failed)
 
     def test_process_jids_noresults(self):
         result_code = self.parser.process_jids({}, 1)


### PR DESCRIPTION
```/System/Library/Frameworks/Python.framework/Versions/2.7/bin/python2.7 "/Applications/PyCharm CE.app/Contents/helpers/pycharm/_jb_nosetest_runner.py" --target salt_return_parser_test.py::SaltReturnParserTest.test_parse_last_return_with_results
Testing started at 4:00 PM ...
Launching Nosetest with arguments /Applications/PyCharm CE.app/Contents/helpers/pycharm/_jb_nosetest_runner.py salt_return_parser_test.py:SaltReturnParserTest.test_parse_last_return_with_results in /Users/isingh/Documents/salt/salt-nanny/tests2017-12-06 16:00:34,750 INFO Latest jid for Minion:minion1 JID:0
2017-12-06 16:00:34,751 INFO [False, False, False, False, True]

.
----------------------------------------------------------------------
Ran 1 test in 0.006s

OK
Process finished with exit code 0```