### PR TITLE
(19.06.0) DEVOPS-12019: updated list of possible failures for salt-nanny

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ python:
   - "2.7"
 install:
   - pip install -r tests/requirements.txt
-  - pip install coveralls
+  - pip install pycparser==2.18
+  - pip install idna==2.6
+  - pip install coveralls==1.2.0
 script:
   - coverage run --source . setup.py nosetests
 after_success:

--- a/saltnanny/salt_return_parser.py
+++ b/saltnanny/salt_return_parser.py
@@ -99,7 +99,8 @@ class SaltReturnParser:
                 'Data failed to compile:',
                 'Pillar failed to render with the following messages:',
                 'Detected conflicting IDs',
-                'Cannot extend ID'
+                'Cannot extend ID',
+                'not available on the salt master or through a configured fileserver'
             ]
             failures = [failure in result for failure in possible_failures]
             self.log.info(failures)

--- a/tests/resources/failed_highstate.json
+++ b/tests/resources/failed_highstate.json
@@ -54,6 +54,14 @@
       "result": true,
       "duration": 10.328,
       "__run_num__": 119
+    },
+    "file_|-/etc/pam.d/sshd_|-/etc/pam.d/sshd_|-managed": {
+      "comment": "not available on the salt master or through a configured fileserver",
+      "name": "/etc/pam.d/sshd",
+      "start_time": "11:56:04.497402",
+      "result": true,
+      "duration": 10.328,
+      "__run_num__": 119
     }
   },
   "retcode": 2,


### PR DESCRIPTION
Tested the code still packages and installs:
```
[root@saltmaster salt-nanny (DEVOPS-12019)]# pip install . && date
You are using pip version 7.1.0, however version 19.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Processing /vagrant_data/projects/salt-nanny
Requirement already satisfied (use --upgrade to upgrade): redis in /usr/lib/python2.6/site-packages (from saltnanny==0.2.2)
Installing collected packages: saltnanny
  Running setup.py install for saltnanny
Successfully installed saltnanny-0.2.2
Wed Jan 23 15:17:35 PST 2019
```