### PR TITLE
DEVOPS-12019: increments salt-nanny version and pins pip packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 redis>=2.0.0
+cryptography==2.1.4

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def get_required_modules(file_name):
 
 setup(
     name="saltnanny",
-    version="0.2.2",
+    version="0.2.3",
     author="Dun and Bradstreet Inc.",
     author_email="devops@dandb.com",
     description='Python Module that parses salt returns stored in an external job cache and logs output',

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 nose>=1.3.7
 mock>=2.0.0
-fakeredis>=0.7.0
+fakeredis==0.9.0


### PR DESCRIPTION
Updated pypi_release_saltnanny jenkins job to use this fork/branch:
<img width="1228" alt="screen shot 2019-01-24 at 2 54 48 pm" src="https://user-images.githubusercontent.com/588833/51713830-24b18c00-1fe8-11e9-84bc-d78a804695ba.png">

Received a passing build:
<img width="1447" alt="screen shot 2019-01-24 at 2 55 18 pm" src="https://user-images.githubusercontent.com/588833/51713848-2c713080-1fe8-11e9-9100-114935c2d390.png">
